### PR TITLE
UX: Put gradient below header

### DIFF
--- a/scss/card-filters.scss
+++ b/scss/card-filters.scss
@@ -37,7 +37,7 @@
     );
     display: block;
     position: absolute;
-    z-index: z("header");
+    z-index: z("header") - 1;
     top: 0;
   }
   &::after {


### PR DESCRIPTION
This adds a small fix for the gradient on scroll to be below the discourse header.