### PR TITLE
FIX: Use proper links in category/tag cards

### DIFF
--- a/javascripts/discourse/components/category-wrapper.js
+++ b/javascripts/discourse/components/category-wrapper.js
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { action } from "@ember/object";
 import { service } from "@ember/service";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
@@ -8,21 +7,6 @@ export default Component.extend({
   router: service(),
   tagName: "",
   listOrder: ["title", "activity"],
-
-  init() {
-    this._super(...arguments);
-  },
-
-  @action
-  selectCategory() {
-    this.get("router").transitionTo("docs.index", {
-      queryParams: {
-        category: this.category.id,
-        order: this.order,
-        ascending: this.ascending,
-      },
-    });
-  },
 
   @discourseComputed("category")
   categoryInfo(category) {

--- a/javascripts/discourse/components/tag-wrapper.js
+++ b/javascripts/discourse/components/tag-wrapper.js
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { action } from "@ember/object";
 import { service } from "@ember/service";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
@@ -7,21 +6,6 @@ import I18n from "I18n";
 export default Component.extend({
   router: service(),
   tagName: "",
-
-  init() {
-    this._super(...arguments);
-  },
-
-  @action
-  selectTag() {
-    this.get("router").transitionTo("docs.index", {
-      queryParams: {
-        tags: this.tag.id,
-        order: this.order,
-        ascending: this.ascending,
-      },
-    });
-  },
 
   @discourseComputed("tagOrders", "tag.id")
   order(orders, id) {

--- a/javascripts/discourse/templates/components/category-wrapper.hbs
+++ b/javascripts/discourse/templates/components/category-wrapper.hbs
@@ -1,6 +1,10 @@
-<a
-  {{on "click" this.selectCategory}}
-  href
+<LinkTo
+  @route="docs.index"
+  @query={{hash
+    category=this.category.id
+    order=this.order
+    ascending=this.ascending
+  }}
   class="docs-card-box category-card card-{{categorySlug}}"
 >
   <div class="docs-card-box-header">
@@ -20,4 +24,4 @@
   {{/if}}
 
   <span class="docs-card-box-count">{{topicCount}}</span>
-</a>
+</LinkTo>

--- a/javascripts/discourse/templates/components/tag-wrapper.hbs
+++ b/javascripts/discourse/templates/components/tag-wrapper.hbs
@@ -1,6 +1,10 @@
-<a
-  {{on "click" this.selectTag}}
-  href
+<LinkTo
+  @route="docs.index"
+  @query={{hash
+    tags=this.category.id
+    order=this.order
+    ascending=this.ascending
+  }}
   class="docs-card-box tag-card card-{{tag.id}}"
 >
   <div class="docs-card-box-header">
@@ -13,4 +17,4 @@
   </div>
 
   <span class="docs-card-box-count">{{topicCount}}</span>
-</a>
+</LinkTo>


### PR DESCRIPTION
Fixes full page transitions (1fe5375a9d026e4df4b1e52456f2a7c17dcc5af6 regression)

reported in https://meta.discourse.org/t/clicking-on-docs-card-filter-reload-the-page/301728